### PR TITLE
Widen glimmer syntax renage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@glimmer/reference": "^0.84.3",
-    "@glimmer/syntax": "^0.84.3",
+    "@glimmer/syntax": ">= 0.84.3",
     "@glimmer/validator": "^0.84.3",
     "async-promise-queue": "^1.0.5",
     "colors": "^1.4.0",


### PR DESCRIPTION
pnpm treats ^ on pre-1.0 versions as patch-range-only updates.

When using ember-source 5.9+, if you have addons that transform HBS, they will likely use @glimmer/syntax 0.84.3. But with the visitor-invoker in ember-source's template-compiler, TOOOONS of deprecations get logged -- this usually blows past your terminal's scroll buffer, as well as GitHub's web-logging (you have to download logs). @glimmer/syntax throughout the dependency graph should be at least 0.92.3. or all transforms need to support both 0.84.3 and 0.92... which usually involves some form of:

```js
/**
 * node.path.original is DEPRECATED in newer versions of @glimmer/syntax
 * '.value' is the new property to use, but it does not exist in older versions
 * of @glimmer/syntax
 */
function getValue(node) {
	if (!node) {
		return;
	}

	const name = 'value' in node ? node.value : node.original;

	return name;
}

	const functionName = getValue(node.path);

    // ...
    // @glimmer/syntax > 0.84.3
    if ('value' in node.path) {
	    node.path.value = 't';
	    node.path.parts = ['t', ...node.path.parts.slice(1)];
	    node.params = [node.params[0]];
	    node.params[0].value = node.params[0].value = id;
    } else {
	    // @glimmer/syntax 0.84.3 and earlier
	    node.path.original = 't';
	    node.path.parts[0] = 't';
	    node.params = [node.params[0]];
	    node.params[0].value = node.params[0].original = id;
    }
```